### PR TITLE
feat: persist food logs to Supabase

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
-  MealEntry,
   MealType,
   getConsumedCalories,
   FoodImage,
@@ -12,8 +11,10 @@ import {
   analysisToFormData,
   AddFoodFormData,
 } from '@/app/types/meal';
-import { mockMeals, DAILY_CALORIE_TARGET } from '@/app/data/mockMeals';
+import { DAILY_CALORIE_TARGET } from '@/app/data/mockMeals';
 import { analyzeFood, resizeImage, isValidImageFormat } from '@/app/services/foodAnalysis';
+import { useFoodLogs } from '@/app/hooks/useFoodLogs';
+import { createClient } from '@/lib/supabase/client';
 import CalorieProgress from '@/app/components/dashboard/CalorieProgress';
 import MealTimeline from '@/app/components/dashboard/MealTimeline';
 import AddFoodForm from '@/app/components/dashboard/AddFoodForm';
@@ -25,8 +26,13 @@ import DashboardHeader from '@/app/components/dashboard/DashboardHeader';
 type FormMode = 'image-upload' | 'manual-entry' | 'analyzing' | 'results';
 
 export default function DashboardPage() {
-  const [meals, setMeals] = useState<MealEntry[]>(mockMeals);
+  // Use database-backed food logs hook
+  const { meals, isLoading, error, addMeal } = useFoodLogs();
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // User state for webhook authentication
+  const [userId, setUserId] = useState<string | null>(null);
 
   // T033: Form mode state
   const [formMode, setFormMode] = useState<FormMode>('image-upload');
@@ -34,11 +40,22 @@ export default function DashboardPage() {
   // T034: Selected image state
   const [selectedImage, setSelectedImage] = useState<FoodImage | null>(null);
 
+  // Selected meal type for analysis
+  const [selectedMealType, setSelectedMealType] = useState<MealType | undefined>(undefined);
+
   // T035: Analysis state
   const [analysisState, setAnalysisState] = useState<AnalysisState>(initialAnalysisState);
 
   // T036: Analysis result state
   const [analysisResult, setAnalysisResult] = useState<NutritionAnalysis | null>(null);
+
+  // Fetch user on mount
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUserId(user?.id ?? null);
+    });
+  }, []);
 
   const consumed = getConsumedCalories(meals);
 
@@ -46,6 +63,7 @@ export default function DashboardPage() {
     setIsFormOpen(true);
     setFormMode('image-upload');
     setSelectedImage(null);
+    setSelectedMealType(undefined);
     setAnalysisState(initialAnalysisState);
     setAnalysisResult(null);
   };
@@ -58,6 +76,7 @@ export default function DashboardPage() {
     setIsFormOpen(false);
     setFormMode('image-upload');
     setSelectedImage(null);
+    setSelectedMealType(undefined);
     setAnalysisState(initialAnalysisState);
     setAnalysisResult(null);
   };
@@ -99,6 +118,15 @@ export default function DashboardPage() {
   const handleAnalyze = useCallback(async () => {
     if (!selectedImage) return;
 
+    if (!userId) {
+      setAnalysisState({
+        status: 'error',
+        error: 'Please log in to analyze food images.',
+        retryCount: 0,
+      });
+      return;
+    }
+
     setFormMode('analyzing');
     setAnalysisState((prev) => ({
       ...prev,
@@ -110,12 +138,17 @@ export default function DashboardPage() {
       // Resize image before sending
       const resizedBlob = await resizeImage(selectedImage.file);
 
-      // Call the webhook
-      const result = await analyzeFood(resizedBlob, (attempt) => {
-        setAnalysisState((prev) => ({
-          ...prev,
-          retryCount: attempt,
-        }));
+      // Call the webhook with user_id and optional meal_type
+      const result = await analyzeFood({
+        image: resizedBlob,
+        userId,
+        mealType: selectedMealType,
+        onRetry: (attempt) => {
+          setAnalysisState((prev) => ({
+            ...prev,
+            retryCount: attempt,
+          }));
+        },
       });
 
       setAnalysisResult(result);
@@ -137,7 +170,7 @@ export default function DashboardPage() {
       }));
       setFormMode('image-upload');
     }
-  }, [selectedImage]);
+  }, [selectedImage, userId, selectedMealType]);
 
   // T039: Handle retry action
   const handleRetry = useCallback(() => {
@@ -151,8 +184,8 @@ export default function DashboardPage() {
     setAnalysisResult(null);
   }, []);
 
-  // Handle add meal (with macros)
-  const handleAddMeal = (mealData: {
+  // Handle add meal (with macros) - now persists to database
+  const handleAddMeal = async (mealData: {
     name: string;
     calories: number;
     mealType?: MealType;
@@ -160,18 +193,21 @@ export default function DashboardPage() {
     carbs?: number;
     fat?: number;
   }) => {
-    const newMeal: MealEntry = {
-      id: crypto.randomUUID(),
-      name: mealData.name,
-      calories: mealData.calories,
-      timestamp: new Date(),
-      mealType: mealData.mealType,
-      protein: mealData.protein,
-      carbs: mealData.carbs,
-      fat: mealData.fat,
-    };
-    setMeals((prev) => [...prev, newMeal]);
-    handleCloseForm();
+    setSubmitError(null);
+    try {
+      await addMeal({
+        name: mealData.name,
+        calories: mealData.calories,
+        timestamp: new Date(),
+        mealType: mealData.mealType,
+        protein: mealData.protein,
+        carbs: mealData.carbs,
+        fat: mealData.fat,
+      });
+      handleCloseForm();
+    } catch {
+      setSubmitError('Failed to save meal. Please try again.');
+    }
   };
 
   // T042: Get initial data for form from analysis result
@@ -195,6 +231,18 @@ export default function DashboardPage() {
         <section className="mb-8">
           <CalorieProgress consumed={consumed} target={DAILY_CALORIE_TARGET} />
         </section>
+
+        {/* Error notification for data loading/saving errors */}
+        {(error || submitError) && (
+          <section className="mb-4">
+            <div className="rounded-xl bg-red-500/10 border border-red-500/20 p-4 flex items-center gap-3">
+              <svg className="w-5 h-5 text-red-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <p className="text-red-400 text-sm">{error || submitError}</p>
+            </div>
+          </section>
+        )}
 
         {!isFormOpen && (
           <section className="mb-8">
@@ -247,6 +295,31 @@ export default function DashboardPage() {
                     onRemoveImage={handleRemoveImage}
                     disabled={analysisState.status === 'analyzing'}
                   />
+
+                  {/* Meal type selector (optional) */}
+                  {selectedImage && analysisState.status === 'ready' && (
+                    <div className="mt-4">
+                      <label className="block text-sm font-medium text-[#A0A0B8] mb-2">
+                        Meal Type (optional)
+                      </label>
+                      <div className="flex flex-wrap gap-2">
+                        {(['Breakfast', 'Lunch', 'Dinner', 'Snack'] as MealType[]).map((type) => (
+                          <button
+                            key={type}
+                            type="button"
+                            onClick={() => setSelectedMealType(selectedMealType === type ? undefined : type)}
+                            className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                              selectedMealType === type
+                                ? 'bg-gradient-to-r from-[#FF6B35] to-[#FF3366] text-white'
+                                : 'bg-white/5 text-[#A0A0B8] hover:bg-white/10'
+                            }`}
+                          >
+                            {type}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
 
                   {/* T043: Analyze button when image is selected */}
                   {selectedImage && analysisState.status === 'ready' && (
@@ -307,7 +380,19 @@ export default function DashboardPage() {
         )}
 
         <section className="mb-8">
-          <MealTimeline meals={meals} onAddClick={handleOpenForm} />
+          {isLoading ? (
+            <div className="rounded-3xl bg-gradient-to-br from-[#252541] to-[#0F0F1A] border border-white/5 p-8 flex items-center justify-center">
+              <div className="flex items-center gap-3 text-[#A0A0B8]">
+                <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                <span>Loading meals...</span>
+              </div>
+            </div>
+          ) : (
+            <MealTimeline meals={meals} onAddClick={handleOpenForm} />
+          )}
         </section>
       </main>
     </div>

--- a/app/hooks/useFoodLogs.ts
+++ b/app/hooks/useFoodLogs.ts
@@ -1,0 +1,91 @@
+// app/hooks/useFoodLogs.ts
+// React hook for managing food logs with Supabase persistence
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { MealEntry } from '@/app/types/meal';
+import { getFoodLogsByDate, createFoodLog, deleteFoodLog } from '@/lib/services/foodLogs';
+
+interface UseFoodLogsResult {
+  meals: MealEntry[];
+  isLoading: boolean;
+  error: string | null;
+  addMeal: (meal: Omit<MealEntry, 'id'>) => Promise<void>;
+  removeMeal: (id: string) => Promise<void>;
+  refreshMeals: () => Promise<void>;
+}
+
+/**
+ * Hook for managing food logs with database persistence
+ * @param date - The date to fetch logs for (defaults to today)
+ */
+export function useFoodLogs(date?: Date): UseFoodLogsResult {
+  const [meals, setMeals] = useState<MealEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Memoize date string to prevent unnecessary re-renders
+  const dateKey = useMemo(() => {
+    const d = date ?? new Date();
+    return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+  }, [date]);
+
+  // Fetch meals for the specified date
+  const refreshMeals = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const fetchDate = date ?? new Date();
+      const fetchedMeals = await getFoodLogsByDate(fetchDate);
+      setMeals(fetchedMeals);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load meals';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dateKey]);
+
+  // Initial fetch on mount and when date changes
+  useEffect(() => {
+    refreshMeals();
+  }, [refreshMeals]);
+
+  // Add a new meal
+  const addMeal = useCallback(async (meal: Omit<MealEntry, 'id'>) => {
+    setError(null);
+
+    try {
+      const newMeal = await createFoodLog(meal);
+      setMeals((prev) => [...prev, newMeal]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add meal';
+      setError(message);
+      throw err; // Re-throw so caller can handle
+    }
+  }, []);
+
+  // Remove a meal
+  const removeMeal = useCallback(async (id: string) => {
+    setError(null);
+
+    try {
+      await deleteFoodLog(id);
+      setMeals((prev) => prev.filter((meal) => meal.id !== id));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to remove meal';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  return {
+    meals,
+    isLoading,
+    error,
+    addMeal,
+    removeMeal,
+    refreshMeals,
+  };
+}

--- a/app/services/foodAnalysis.ts
+++ b/app/services/foodAnalysis.ts
@@ -1,4 +1,4 @@
-import { NutritionAnalysis } from '@/app/types/meal';
+import { NutritionAnalysis, MealType } from '@/app/types/meal';
 
 // T010: Supported image formats
 const SUPPORTED_FORMATS = [
@@ -171,17 +171,24 @@ async function withRetry<T>(
   throw lastError;
 }
 
+/** Options for food analysis */
+export interface AnalyzeFoodOptions {
+  image: Blob;
+  userId: string;
+  mealType?: MealType;
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
 /**
  * Analyzes a food image using the AI webhook
- * @param image - The image blob to analyze
- * @param onRetry - Optional callback called when a retry attempt is made
+ * @param options - Analysis options including image, userId, and optional mealType
  * @returns Nutrition analysis results from the AI
  * @throws FoodAnalysisError on failure
  */
 export async function analyzeFood(
-  image: Blob,
-  onRetry?: (attempt: number, error: Error) => void
+  options: AnalyzeFoodOptions
 ): Promise<NutritionAnalysis> {
+  const { image, userId, mealType, onRetry } = options;
   const webhookUrl = process.env.NEXT_PUBLIC_WEBHOOK_URL;
 
   if (!webhookUrl) {
@@ -191,10 +198,21 @@ export async function analyzeFood(
     } as FoodAnalysisError;
   }
 
+  if (!userId) {
+    throw {
+      message: 'User not authenticated. Please log in.',
+      retryable: false,
+    } as FoodAnalysisError;
+  }
+
   return withRetry(
     async () => {
       const formData = new FormData();
       formData.append('image', image, 'food.jpg');
+      formData.append('user_id', userId);
+      if (mealType) {
+        formData.append('meal_type', mealType);
+      }
 
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 60000); // 60s timeout

--- a/lib/services/foodLogs.ts
+++ b/lib/services/foodLogs.ts
@@ -1,0 +1,117 @@
+// lib/services/foodLogs.ts
+// Service layer for food log CRUD operations
+
+import { createClient } from '@/lib/supabase/client';
+import type { FoodLogRow, FoodLogInsert } from '@/types/database';
+import type { MealEntry } from '@/app/types/meal';
+
+/**
+ * Convert database row to MealEntry format
+ */
+export function foodLogRowToMealEntry(row: FoodLogRow): MealEntry {
+  return {
+    id: row.id,
+    name: row.food_name,
+    calories: row.calories,
+    timestamp: new Date(row.logged_at),
+    mealType: row.meal_type ?? undefined,
+    protein: row.protein,
+    carbs: row.carbs,
+    fat: row.fat,
+  };
+}
+
+/**
+ * Convert MealEntry to database insert format
+ */
+export function mealEntryToFoodLogInsert(meal: Omit<MealEntry, 'id'>): FoodLogInsert {
+  return {
+    food_name: meal.name,
+    calories: meal.calories,
+    protein: meal.protein ?? 0,
+    carbs: meal.carbs ?? 0,
+    fat: meal.fat ?? 0,
+    meal_type: meal.mealType ?? null,
+    logged_at: meal.timestamp.toISOString(),
+  };
+}
+
+/**
+ * Fetch food logs for a specific date (user's local date)
+ */
+export async function getFoodLogsByDate(date: Date): Promise<MealEntry[]> {
+  const supabase = createClient();
+
+  // Get start and end of day in UTC
+  const startOfDay = new Date(date);
+  startOfDay.setHours(0, 0, 0, 0);
+
+  const endOfDay = new Date(date);
+  endOfDay.setHours(23, 59, 59, 999);
+
+  const { data, error } = await supabase
+    .from('food_logs')
+    .select('*')
+    .gte('logged_at', startOfDay.toISOString())
+    .lte('logged_at', endOfDay.toISOString())
+    .order('logged_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch food logs: ${error.message}`);
+  }
+
+  return (data as FoodLogRow[]).map(foodLogRowToMealEntry);
+}
+
+/**
+ * Create a new food log entry
+ */
+export async function createFoodLog(meal: Omit<MealEntry, 'id'>): Promise<MealEntry> {
+  const supabase = createClient();
+
+  // Get current user
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    throw new Error('User not authenticated');
+  }
+
+  const insertData = {
+    ...mealEntryToFoodLogInsert(meal),
+    user_id: user.id,
+  };
+
+  const { data, error } = await supabase
+    .from('food_logs')
+    .insert(insertData)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create food log: ${error.message}`);
+  }
+
+  return foodLogRowToMealEntry(data as FoodLogRow);
+}
+
+// UUID validation regex
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Delete a food log entry
+ */
+export async function deleteFoodLog(id: string): Promise<void> {
+  if (!UUID_REGEX.test(id)) {
+    throw new Error('Invalid food log ID');
+  }
+
+  const supabase = createClient();
+
+  const { error } = await supabase
+    .from('food_logs')
+    .delete()
+    .eq('id', id);
+
+  if (error) {
+    throw new Error(`Failed to delete food log: ${error.message}`);
+  }
+}

--- a/supabase/migrations/001_create_food_logs.sql
+++ b/supabase/migrations/001_create_food_logs.sql
@@ -1,0 +1,34 @@
+-- Migration: Create food_logs table
+-- Description: Stores user food log entries with nutritional information
+
+CREATE TABLE public.food_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  food_name TEXT NOT NULL,
+  calories INTEGER NOT NULL CHECK (calories >= 0),
+  protein REAL DEFAULT 0 CHECK (protein >= 0),
+  carbs REAL DEFAULT 0 CHECK (carbs >= 0),
+  fat REAL DEFAULT 0 CHECK (fat >= 0),
+  meal_type TEXT CHECK (meal_type IN ('Breakfast', 'Lunch', 'Dinner', 'Snack')),
+  logged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX idx_food_logs_user_id ON public.food_logs(user_id);
+CREATE INDEX idx_food_logs_user_date ON public.food_logs(user_id, logged_at);
+
+-- RLS Policies
+ALTER TABLE public.food_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own food logs" ON public.food_logs
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own food logs" ON public.food_logs
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own food logs" ON public.food_logs
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own food logs" ON public.food_logs
+  FOR DELETE USING (auth.uid() = user_id);

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,0 +1,33 @@
+// types/database.ts
+// TypeScript types for Supabase database tables
+
+import type { MealType } from '@/app/types/meal';
+
+/**
+ * Database row shape for food_logs table
+ */
+export interface FoodLogRow {
+  id: string;
+  user_id: string;
+  food_name: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  meal_type: MealType | null;
+  logged_at: string;
+  created_at: string;
+}
+
+/**
+ * Insert payload for food_logs (user_id auto-set from auth)
+ */
+export interface FoodLogInsert {
+  food_name: string;
+  calories: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  meal_type?: MealType | null;
+  logged_at?: string;
+}


### PR DESCRIPTION
## Summary
- Add `food_logs` table with RLS policies for secure user data isolation
- Create service layer and React hook for CRUD operations with DB sync
- Update dashboard to persist meals across page refreshes
- Add `user_id` and `meal_type` to n8n webhook requests for Supabase RLS
- Add meal type selector UI before food analysis

## Files Changed
| File | Purpose |
|------|---------|
| `supabase/migrations/001_create_food_logs.sql` | DB schema + RLS policies |
| `types/database.ts` | TypeScript types for DB |
| `lib/services/foodLogs.ts` | CRUD operations |
| `app/hooks/useFoodLogs.ts` | React state + DB sync |
| `app/services/foodAnalysis.ts` | Webhook with user_id/meal_type |
| `app/dashboard/page.tsx` | Use hook, add meal type selector |

## Test plan
- [ ] Run migration in Supabase SQL editor
- [ ] Add food via image analysis, verify row in `food_logs` table
- [ ] Refresh page, verify meals persist
- [ ] Test RLS: different user cannot see other's data

🤖 Generated with [Claude Code](https://claude.com/claude-code)